### PR TITLE
ヘルスチェックパスをルートURLに変更

### DIFF
--- a/cloudformation/ecs-cluster.yml
+++ b/cloudformation/ecs-cluster.yml
@@ -166,7 +166,7 @@ Resources:
   TargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
-      HealthCheckPath: /health/
+      HealthCheckPath: /
       HealthCheckIntervalSeconds: 30
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2


### PR DESCRIPTION
CloudFormation TargetGroupのヘルスチェックパスを/health/から/に変更し、ルートURLでヘルスチェックを行うようにしました。