### PR TITLE
スタック名とリソース名を変更して新規作成

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Deploy ECS Cluster
       run: |
         aws cloudformation deploy \
-          --stack-name django-ecs-cluster-staging \
+          --stack-name django-ecs-cluster-staging-new \
           --template-file cloudformation/ecs-cluster.yml \
           --capabilities CAPABILITY_IAM \
           --parameter-overrides Environment=staging \
@@ -59,7 +59,7 @@ jobs:
     - name: Deploy ECS Service
       run: |
         aws cloudformation deploy \
-          --stack-name django-ecs-service-staging \
+          --stack-name django-ecs-service-staging-new \
           --template-file cloudformation/ecs-service-staging.yml \
           --parameter-overrides \
             ImageUrl=$IMAGE_URI \
@@ -67,7 +67,7 @@ jobs:
           
     - name: Get Application URL
       run: |
-        ALB_DNS=$(aws cloudformation describe-stacks --stack-name django-ecs-cluster-staging --query "Stacks[0].Outputs[?OutputKey=='LoadBalancerDNSName'].OutputValue" --output text)
+        ALB_DNS=$(aws cloudformation describe-stacks --stack-name django-ecs-cluster-staging-new --query "Stacks[0].Outputs[?OutputKey=='LoadBalancerDNSName'].OutputValue" --output text)
         echo "::notice ::ステージング環境URL: http://$ALB_DNS"
         
     - name: Notify Slack

--- a/cloudformation/ecs-cluster.yml
+++ b/cloudformation/ecs-cluster.yml
@@ -127,7 +127,7 @@ Resources:
   ECSCluster:
     Type: AWS::ECS::Cluster
     Properties:
-      ClusterName: django-ecs-cluster
+      ClusterName: django-ecs-cluster-new
       CapacityProviders:
         - FARGATE
         - FARGATE_SPOT
@@ -190,7 +190,7 @@ Resources:
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: /ecs/django-app
+      LogGroupName: /ecs/django-app-new
       RetentionInDays: 14
 
 Outputs:


### PR DESCRIPTION
CloudFormationスタックを新規作成するため、スタック名とリソース名を変更しました。これにより、古いスタックとの競合を避けることができます。