### PR TITLE
docker-compose.yml: django-environライブラリを追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "8080:8000"
     command: >
-      bash -c "pip install django gunicorn &&
+      bash -c "pip install django gunicorn django-environ &&
                if [ ! -f manage.py ]; then django-admin startproject config . && python manage.py migrate; fi &&
                python manage.py runserver 0.0.0.0:8000"
     environment:


### PR DESCRIPTION
ローカル環境で必要なdjango-environライブラリをdocker-compose.ymlに追加しました。これにより、ローカル開発環境でDjangoが正常に起動するようになります。