### PR TITLE
ステージング環境用ECSデプロイの参照整合性を修正

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Deploy ECS Cluster
       run: |
         aws cloudformation deploy \
-          --stack-name django-ecs-cluster-staging-new \
+          --stack-name django-ecs-cluster-staging \
           --template-file cloudformation/ecs-cluster.yml \
           --capabilities CAPABILITY_IAM \
           --no-fail-on-empty-changeset
@@ -66,7 +66,7 @@ jobs:
           
     - name: Get Application URL
       run: |
-        ALB_DNS=$(aws cloudformation describe-stacks --stack-name django-ecs-cluster-staging-new --query "Stacks[0].Outputs[?OutputKey=='LoadBalancerDNSName'].OutputValue" --output text)
+        ALB_DNS=$(aws cloudformation describe-stacks --stack-name django-ecs-cluster-staging --query "Stacks[0].Outputs[?OutputKey=='LoadBalancerDNSName'].OutputValue" --output text)
         echo "::notice ::ステージング環境URL: http://$ALB_DNS"
         
     - name: Notify Slack

--- a/cloudformation/ecs-service-staging.yml
+++ b/cloudformation/ecs-service-staging.yml
@@ -35,10 +35,10 @@ Resources:
         - FARGATE
       ExecutionRoleArn:
         Fn::ImportValue:
-          !Sub 'django-ecs-cluster-ECSTaskExecutionRole'
+          !Sub 'django-ecs-cluster-staging-ECSTaskExecutionRole'
       TaskRoleArn:
         Fn::ImportValue:
-          !Sub 'django-ecs-cluster-ECSTaskExecutionRole'
+          !Sub 'django-ecs-cluster-staging-ECSTaskExecutionRole'
       ContainerDefinitions:
         - Name: django-app
           Image: !Ref ImageUrl
@@ -71,7 +71,7 @@ Resources:
       ServiceName: django-ecs-service-staging
       Cluster:
         Fn::ImportValue:
-          !Sub 'django-ecs-cluster-ECSCluster'
+          !Sub 'django-ecs-cluster-staging-ECSCluster'
       TaskDefinition: !Ref TaskDefinition
       DesiredCount: !Ref DesiredCount
       LaunchType: FARGATE
@@ -80,18 +80,18 @@ Resources:
           AssignPublicIp: ENABLED
           SecurityGroups:
             - Fn::ImportValue:
-                !Sub 'django-ecs-cluster-ECSSecurityGroup'
+                !Sub 'django-ecs-cluster-staging-ECSSecurityGroup'
           Subnets:
             - Fn::ImportValue:
-                !Sub 'django-ecs-cluster-PublicSubnet1'
+                !Sub 'django-ecs-cluster-staging-PublicSubnet1'
             - Fn::ImportValue:
-                !Sub 'django-ecs-cluster-PublicSubnet2'
+                !Sub 'django-ecs-cluster-staging-PublicSubnet2'
       LoadBalancers:
         - ContainerName: django-app
           ContainerPort: 8000
           TargetGroupArn:
             Fn::ImportValue:
-              !Sub 'django-ecs-cluster-TargetGroup'
+              !Sub 'django-ecs-cluster-staging-TargetGroup'
       DeploymentConfiguration:
         MinimumHealthyPercent: 100
         MaximumPercent: 200
@@ -103,7 +103,7 @@ Resources:
     Properties:
       ListenerArn:
         Fn::ImportValue:
-          !Sub 'django-ecs-cluster-ALBListener'
+          !Sub 'django-ecs-cluster-staging-ALBListener'
       Priority: 2
       Conditions:
         - Field: path-pattern
@@ -113,7 +113,7 @@ Resources:
         - Type: forward
           TargetGroupArn:
             Fn::ImportValue:
-              !Sub 'django-ecs-cluster-TargetGroup'
+              !Sub 'django-ecs-cluster-staging-TargetGroup'
 
   # Auto Scaling - 制限されたスケーリング設定
   ScalableTarget:
@@ -125,7 +125,7 @@ Resources:
         - /
         - - service
           - Fn::ImportValue:
-              !Sub 'django-ecs-cluster-ECSCluster'
+              !Sub 'django-ecs-cluster-staging-ECSCluster'
           - !GetAtt Service.Name
       ScalableDimension: ecs:service:DesiredCount
       ServiceNamespace: ecs
@@ -177,7 +177,7 @@ Resources:
         - Name: ClusterName
           Value:
             Fn::ImportValue:
-              !Sub 'django-ecs-cluster-ECSCluster'
+              !Sub 'django-ecs-cluster-staging-ECSCluster'
         - Name: ServiceName
           Value: !GetAtt Service.Name
       ComparisonOperator: GreaterThanThreshold
@@ -199,7 +199,7 @@ Resources:
         - Name: ClusterName
           Value:
             Fn::ImportValue:
-              !Sub 'django-ecs-cluster-ECSCluster'
+              !Sub 'django-ecs-cluster-staging-ECSCluster'
         - Name: ServiceName
           Value: !GetAtt Service.Name
       ComparisonOperator: LessThanThreshold


### PR DESCRIPTION
修正内容: クラスタースタック名とサービステンプレートの参照値を一致させ、整合性を確保した。