### PR TITLE
ロググループ名の環境変数展開を修正

### DIFF
--- a/cloudformation/ecs-service.yml
+++ b/cloudformation/ecs-service.yml
@@ -55,7 +55,7 @@ Resources:
           LogConfiguration:
             LogDriver: awslogs
             Options:
-              awslogs-group: /ecs/django-app-${Environment}
+              awslogs-group: !Sub "/ecs/django-app-${Environment}"
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: django-app
           Environment:


### PR DESCRIPTION
CloudFormationテンプレートでロググループ名の環境変数が正しく展開されるように修正