### PR TITLE
fix: TimestampSuffixパラメータにタイムスタンプを設定

### DIFF
--- a/.github/workflows/auto_deploy_staging.yml
+++ b/.github/workflows/auto_deploy_staging.yml
@@ -99,7 +99,7 @@ jobs:
             --template-file cloudformation/ecs-service-staging.yml \
             --parameter-overrides \
               ImageUrl=$IMAGE_URI \
-              TimestampSuffix= \
+              TimestampSuffix=${{ env.TIMESTAMP }} \
             --no-fail-on-empty-changeset \
             --debug 2>&1 | tee logs/service-deploy.log
           


### PR DESCRIPTION
CloudFormationのデプロイ時にTimestampSuffixパラメータが空になっていた問題を修正