### PR TITLE
fix: actions/upload-artifactをv4に更新

### DIFF
--- a/.github/workflows/auto_deploy_staging.yml
+++ b/.github/workflows/auto_deploy_staging.yml
@@ -143,7 +143,7 @@ jobs:
       
       - name: Upload Logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: deployment-logs-${{ env.TIMESTAMP }}
           path: logs/


### PR DESCRIPTION
非推奨となったactions/upload-artifact@v3を最新のv4に更新します。