### PR TITLE
feat: Option B デプロイ戦略の実装 - ステージング環境CI/CD改善

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -158,6 +158,13 @@ AWS ECSデプロイ関連の支援をリクエストする際は以下の形式�
        run: ruff check app
      ``` 
 
+## ステージングデプロイ必読
+- **デプロイ作業前に必ず `docs/staging-deploy.md` を参照すること**
+- **Option B（ハイブリッド方式）に従い、VPCの新規作成は行わない**
+- **タイムスタンプ付きスタック名は使用禁止**
+- 固定リソース名を使用: `django-ecs-cluster-staging`, `django-ecs-service-staging`
+- 基盤インフラは1回だけ作成、以降はアプリケーションのみ更新
+
 # AWS ECS デプロイ競合問題 - 技術書
 ## 重要：生成AI必読！このセクションを理解してからECSデプロイ支援を行うこと
 

--- a/.github/workflows/auto_deploy_staging.yml
+++ b/.github/workflows/auto_deploy_staging.yml
@@ -1,4 +1,4 @@
-name: Auto Deploy to Staging
+name: Deploy to Staging (Option B)
 
 on:
   workflow_run:
@@ -7,156 +7,92 @@ on:
     types:
       - completed
 
+env:
+  AWS_REGION: ap-northeast-1
+  ECR_REPOSITORY: django-ecs-app
+  ECS_CLUSTER: django-ecs-cluster-staging
+  ECS_SERVICE: django-ecs-service-staging
+  TASK_DEFINITION_FAMILY: django-app-staging
+
 jobs:
   deploy:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'develop' }}
     runs-on: ubuntu-latest
     environment: staging
+    
     steps:
-      - uses: actions/checkout@v3
-      
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: 'ap-northeast-1'
-      
-      - name: Setup Debug Logging
-        run: |
-          echo "AWS_STS_REGIONAL_ENDPOINTS=regional" >> $GITHUB_ENV
-          echo "AWS_SDK_LOAD_CONFIG=1" >> $GITHUB_ENV
-          echo "AWS_PAGER=" >> $GITHUB_ENV  # AWSのページャーを無効化して全出力を表示
-          mkdir -p logs
-      
-      - name: Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v1
-      
-      - name: Set up variables
-        run: |
-          echo "ECR_REPOSITORY=django-ecs-app" >> $GITHUB_ENV
-          echo "IMAGE_TAG=sha-$(echo ${{ github.event.workflow_run.head_sha }} | cut -c1-7)" >> $GITHUB_ENV
-          echo "AWS_ACCOUNT_ID=${{ secrets.AWS_ACCOUNT_ID }}" >> $GITHUB_ENV
-          echo "AWS_REGION=ap-northeast-1" >> $GITHUB_ENV
-          echo "TIMESTAMP=$(date +%Y%m%d%H%M%S)" >> $GITHUB_ENV
-          echo "STACK_NAME=django-ecs-service-staging-$(date +%Y%m%d%H%M%S)" >> $GITHUB_ENV
-          echo "SERVICE_NAME=django-ecs-service-staging" >> $GITHUB_ENV
-      
-      - name: Build, tag, and push image
-        run: |
-          docker build -t ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/$ECR_REPOSITORY:$IMAGE_TAG -f docker/Dockerfile .
-          docker push ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/$ECR_REPOSITORY:$IMAGE_TAG
-          echo "IMAGE_URI=${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_ENV
-      
-      - name: Deploy ECS Cluster
-        run: |
-          set -x  # デバッグ出力を有効化
-          aws cloudformation deploy \
-            --stack-name django-ecs-cluster-staging \
-            --template-file cloudformation/ecs-cluster.yml \
-            --capabilities CAPABILITY_IAM \
-            --no-fail-on-empty-changeset \
-            --debug 2>&1 | tee logs/cluster-deploy.log
-          set +x
-      
-      - name: Check and Clean Existing ECS Services
-        run: |
-          echo "既存のECSサービスを確認しています..."
-          EXISTING_SERVICES=$(aws ecs list-services --cluster django-ecs-cluster-staging --output json | jq -r '.serviceArns[]' | grep django-ecs-service-staging || echo "")
-          
-          if [ ! -z "$EXISTING_SERVICES" ]; then
-            echo "以下の既存サービスを削除します:"
-            echo "$EXISTING_SERVICES"
-            
-            for SERVICE_ARN in $EXISTING_SERVICES; do
-              SERVICE_NAME=$(echo $SERVICE_ARN | awk -F'/' '{print $NF}')
-              echo "サービス削除中: $SERVICE_NAME"
-              
-              # サービスをドレインして削除
-              aws ecs update-service --cluster django-ecs-cluster-staging --service $SERVICE_NAME --desired-count 0
-              aws ecs wait services-stable --cluster django-ecs-cluster-staging --services $SERVICE_NAME
-              aws ecs delete-service --cluster django-ecs-cluster-staging --service $SERVICE_NAME --force
-              
-              echo "サービス削除完了: $SERVICE_NAME"
-            done
-          else
-            echo "既存のサービスが見つかりませんでした"
-          fi
-      
-      - name: Validate CloudFormation Template
-        run: |
-          echo "サービステンプレートの検証を実行します..."
-          aws cloudformation validate-template \
-            --template-body file://cloudformation/ecs-service-staging.yml \
-            2>&1 | tee logs/template-validation.log
-      
-      - name: Deploy ECS Service
-        id: deploy-service
-        run: |
-          set -x  # デバッグ出力を有効化
-          aws cloudformation deploy \
-            --stack-name ${{ env.STACK_NAME }} \
-            --template-file cloudformation/ecs-service-staging.yml \
-            --parameter-overrides \
-              ImageUrl=$IMAGE_URI \
-              TimestampSuffix=${{ env.TIMESTAMP }} \
-            --no-fail-on-empty-changeset \
-            --debug 2>&1 | tee logs/service-deploy.log
-          
-          # デプロイ成功時のスタック情報を出力
-          echo "スタック詳細情報を取得しています..."
-          aws cloudformation describe-stacks --stack-name ${{ env.STACK_NAME }} \
-            --query "Stacks[0]" --output json | tee logs/stack-details.json
-          set +x
-      
-      - name: Handle CloudFormation Failure
-        if: failure()
-        run: |
-          echo "::error::CloudFormationデプロイが失敗しました。詳細なエラー情報を収集します。"
-          
-          # スタックイベント情報を取得
-          echo "スタックイベント履歴を取得しています..."
-          aws cloudformation describe-stack-events \
-            --stack-name ${{ env.STACK_NAME }} \
-            --query "StackEvents[?ResourceStatus=='CREATE_FAILED'].{Resource:LogicalResourceId,Reason:ResourceStatusReason}" \
-            --output json | tee logs/stack-failures.json
-          
-          # スタックの詳細情報を取得
-          echo "CloudFormationテンプレートで使用されている値:"
-          cat cloudformation/ecs-service-staging.yml | grep -A 5 ContainerCpu
-          cat cloudformation/ecs-service-staging.yml | grep -A 5 ContainerMemory
-          
-          echo "Fargateサポート値の確認："
-          echo "CPU/メモリ組み合わせ: 256/512, 256/1024, 512/1024, 512/2048, 1024/2048, 1024/3072, 1024/4096..."
-          
-          # CloudWatchログの確認
-          echo "CloudWatchログを確認しています..."
-          aws logs describe-log-groups \
-            --log-group-name-prefix "/ecs/django-app-staging" \
-            --output json | tee logs/log-groups.json
-      
-      - name: Announce URL
-        if: success()
-        run: |
-          ALB_DNS=$(aws cloudformation describe-stacks --stack-name django-ecs-cluster-staging --query "Stacks[0].Outputs[?OutputKey=='LoadBalancerDNSName'].OutputValue" --output text)
-          echo "::notice ::ステージングURL: http://$ALB_DNS"
-      
-      - name: Upload Logs
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: deployment-logs-${{ env.TIMESTAMP }}
-          path: logs/
-          retention-days: 7
-      
-      - name: Notify Slack
-        if: always()
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,commit,author,action,eventName,ref,workflow
-          mention: 'here'
-          if_mention: failure
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        continue-on-error: true 
+    - uses: actions/checkout@v3
+    
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ env.AWS_REGION }}
+    
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v2
+    
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        IMAGE_TAG: ${{ github.event.workflow_run.head_sha }}
+      run: |
+        # Build docker image
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f docker/Dockerfile .
+        
+        # Push image to ECR
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        
+        # Output image URI
+        echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+    
+    - name: Download task definition
+      run: |
+        aws ecs describe-task-definition --task-definition ${{ env.TASK_DEFINITION_FAMILY }} \
+          --query taskDefinition > task-definition.json
+    
+    - name: Fill in the new image ID in the task definition
+      id: task-def
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition: task-definition.json
+        container-name: django-app
+        image: ${{ steps.build-image.outputs.image }}
+        environment-variables: |
+          ALLOWED_HOSTS=*.elb.amazonaws.com,staging.grape-app.jp
+          DEBUG=0
+    
+    - name: Deploy Amazon ECS task definition
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      with:
+        task-definition: ${{ steps.task-def.outputs.task-definition }}
+        service: ${{ env.ECS_SERVICE }}
+        cluster: ${{ env.ECS_CLUSTER }}
+        wait-for-service-stability: true
+    
+    - name: Get service info
+      if: success()
+      run: |
+        # Get ALB DNS
+        ALB_DNS=$(aws cloudformation describe-stacks \
+          --stack-name django-ecs-cluster-staging \
+          --query "Stacks[0].Outputs[?OutputKey=='LoadBalancerDNSName'].OutputValue" \
+          --output text)
+        
+        echo "::notice ::ステージング環境にデプロイ完了"
+        echo "::notice ::URL: http://$ALB_DNS"
+        echo "::notice ::カスタムドメイン: https://staging.grape-app.jp"
+    
+    - name: Notify Slack
+      if: always()
+      uses: 8398a7/action-slack@v3
+      with:
+        status: ${{ job.status }}
+        text: |
+          ステージング環境へのデプロイが${{ job.status == 'success' && '成功しました ✅' || '失敗しました ❌' }}
+          コミット: ${{ github.event.workflow_run.head_sha }}
+        webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      continue-on-error: true 

--- a/docs/staging-deploy.md
+++ b/docs/staging-deploy.md
@@ -1,0 +1,346 @@
+# ステージング環境デプロイ手順書（Option B: ハイブリッド方式）
+
+## 概要
+
+本ドキュメントは、AWS ECS へのステージング環境デプロイにおいて、VPC競合問題やALBリスナールール競合を回避するための**Option B（ハイブリッド方式）**の詳細な手順を記載しています。
+
+### Option B（ハイブリッド方式）とは
+
+- **基盤インフラ**（VPC、ALB、ECSクラスター）：CloudFormationで**1回だけ**作成
+- **アプリケーションデプロイ**：GitHub Actions + AWS CLIで既存リソースを更新
+- **新規リソースは作成しない**：VPC上限問題を完全に回避
+
+### なぜこの方式を採用するのか
+
+1. **VPC上限問題の回避**：AWSアカウントのVPC上限は5個（デフォルト）
+2. **ALBリスナールール競合の回避**：タイムスタンプ付きスタック名による無限ループを防止
+3. **高速デプロイ**：インフラ作成なし、アプリケーションのみ更新
+4. **シンプルな管理**：固定リソース名による明確な構成
+
+## 前提条件
+
+- AWS CLIがインストール・設定済み
+- DockerおよびDocker Composeがインストール済み
+- 適切なIAM権限を持つAWSアカウント
+- GitHubリポジトリへのアクセス権限
+
+## 1. 初回セットアップ（基盤インフラの作成）
+
+**⚠️ 重要：この手順は環境ごとに1回だけ実行します**
+
+### 1.1 既存スタックの確認
+
+```bash
+# 既存のECS関連スタックを確認
+aws cloudformation list-stacks \
+  --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE \
+  --query "StackSummaries[?contains(StackName, 'django-ecs')].[StackName,StackStatus]" \
+  --output table
+```
+
+### 1.2 基盤インフラスタックの作成/更新
+
+```bash
+# 環境変数の設定
+export AWS_REGION=ap-northeast-1
+export ENVIRONMENT=staging
+
+# クラスタースタックの作成（VPC、ALB、ECSクラスター含む）
+aws cloudformation deploy \
+  --stack-name django-ecs-cluster-${ENVIRONMENT} \
+  --template-file cloudformation/ecs-cluster.yml \
+  --capabilities CAPABILITY_IAM \
+  --parameter-overrides Environment=${ENVIRONMENT}
+```
+
+### 1.3 作成されるリソース
+
+- **VPC**: 1つのみ（再利用）
+- **パブリック/プライベートサブネット**: 各2つ
+- **ALB**: 1つ（複数サービスで共有）
+- **ECSクラスター**: 1つ
+- **セキュリティグループ**: 必要最小限
+
+### 1.4 重要な出力値の確認
+
+```bash
+# スタックの出力値を確認（後の手順で使用）
+aws cloudformation describe-stacks \
+  --stack-name django-ecs-cluster-${ENVIRONMENT} \
+  --query "Stacks[0].Outputs[*].[OutputKey,OutputValue]" \
+  --output table
+```
+
+## 2. タスク定義の管理
+
+### 2.1 タスク定義JSONファイルの作成
+
+`task-definition-staging.json` を作成：
+
+```json
+{
+  "family": "django-app-staging",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "256",
+  "memory": "512",
+  "executionRoleArn": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/ecsTaskExecutionRole",
+  "containerDefinitions": [
+    {
+      "name": "django-app",
+      "image": "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/django-ecs-app:${IMAGE_TAG}",
+      "portMappings": [
+        {
+          "containerPort": 8000,
+          "protocol": "tcp"
+        }
+      ],
+      "environment": [
+        {
+          "name": "DEBUG",
+          "value": "0"
+        },
+        {
+          "name": "ALLOWED_HOSTS",
+          "value": "*.elb.amazonaws.com,staging.grape-app.jp"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/django-app-staging",
+          "awslogs-region": "${AWS_REGION}",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    }
+  ]
+}
+```
+
+### 2.2 環境変数の管理
+
+- **ALLOWED_HOSTS**: ALBのDNS名とカスタムドメインを含める
+- **DEBUG**: ステージング環境では0（本番モード）
+- その他の環境変数はSecrets Managerから取得することを推奨
+
+## 3. ECSサービスの作成（初回のみ）
+
+**⚠️ 初回のみ実行。2回目以降は「4. CI/CDワークフロー設定」へ**
+
+```bash
+# サービス作成用のJSONファイル
+cat > ecs-service-staging.json << EOF
+{
+  "serviceName": "django-ecs-service-staging",
+  "taskDefinition": "django-app-staging",
+  "loadBalancers": [
+    {
+      "targetGroupArn": "arn:aws:elasticloadbalancing:${AWS_REGION}:${AWS_ACCOUNT_ID}:targetgroup/...",
+      "containerName": "django-app",
+      "containerPort": 8000
+    }
+  ],
+  "desiredCount": 2,
+  "launchType": "FARGATE",
+  "networkConfiguration": {
+    "awsvpcConfiguration": {
+      "subnets": ["subnet-xxx", "subnet-yyy"],
+      "securityGroups": ["sg-xxx"],
+      "assignPublicIp": "DISABLED"
+    }
+  },
+  "healthCheckGracePeriodSeconds": 60
+}
+EOF
+
+# サービスの作成
+aws ecs create-service \
+  --cluster django-ecs-cluster-staging \
+  --cli-input-json file://ecs-service-staging.json
+```
+
+## 4. CI/CDワークフロー設定
+
+### 4.1 GitHub Actions ワークフロー
+
+`.github/workflows/auto_deploy_staging.yml`:
+
+```yaml
+name: Deploy to Staging (Option B)
+
+on:
+  push:
+    branches: [ develop ]
+
+env:
+  AWS_REGION: ap-northeast-1
+  ECR_REPOSITORY: django-ecs-app
+  ECS_CLUSTER: django-ecs-cluster-staging
+  ECS_SERVICE: django-ecs-service-staging
+  TASK_DEFINITION_FAMILY: django-app-staging
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ env.AWS_REGION }}
+    
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v2
+    
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        IMAGE_TAG: ${{ github.sha }}
+      run: |
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f docker/Dockerfile .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+    
+    - name: Fill in the new image ID in the task definition
+      id: task-def
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition: task-definition-staging.json
+        container-name: django-app
+        image: ${{ steps.build-image.outputs.image }}
+    
+    - name: Deploy Amazon ECS task definition
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      with:
+        task-definition: ${{ steps.task-def.outputs.task-definition }}
+        service: ${{ env.ECS_SERVICE }}
+        cluster: ${{ env.ECS_CLUSTER }}
+        wait-for-service-stability: true
+```
+
+### 4.2 重要なポイント
+
+1. **固定リソース名**：タイムスタンプを使用しない
+2. **既存サービスの更新**：新規作成ではなく更新
+3. **タスク定義のバージョニング**：自動的に新しいリビジョンが作成される
+4. **ロールバック可能**：前のタスク定義リビジョンに戻せる
+
+## 5. 手動デプロイ手順（デバッグ用）
+
+CI/CDが動作しない場合の手動デプロイ手順：
+
+```bash
+# 1. ECRにログイン
+aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
+
+# 2. Dockerイメージをビルド・プッシュ
+docker build -t django-ecs-app:latest -f docker/Dockerfile .
+docker tag django-ecs-app:latest $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/django-ecs-app:latest
+docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/django-ecs-app:latest
+
+# 3. タスク定義を登録
+aws ecs register-task-definition --cli-input-json file://task-definition-staging.json
+
+# 4. サービスを更新（新しいタスク定義を使用）
+aws ecs update-service \
+  --cluster django-ecs-cluster-staging \
+  --service django-ecs-service-staging \
+  --task-definition django-app-staging \
+  --force-new-deployment
+```
+
+## 6. トラブルシューティング
+
+### 6.1 VPC上限エラー
+
+```
+The maximum number of VPCs has been reached
+```
+
+**解決方法**：
+1. 既存VPCを再利用（新規作成しない）
+2. 不要なVPCを削除
+3. AWS Supportに上限緩和を申請
+
+### 6.2 ALBリスナールール競合
+
+```
+A rule with the given priority already exists
+```
+
+**解決方法**：
+1. 固定Priority値を使用
+2. 環境ごとに異なるPriority値を設定
+3. Host-headerやPath-patternで分離
+
+### 6.3 タスクが起動しない
+
+```bash
+# タスクの状態を確認
+aws ecs describe-tasks \
+  --cluster django-ecs-cluster-staging \
+  --tasks $(aws ecs list-tasks --cluster django-ecs-cluster-staging --service-name django-ecs-service-staging --query 'taskArns[0]' --output text)
+
+# CloudWatch Logsでエラーを確認
+aws logs tail /ecs/django-app-staging --follow
+```
+
+### 6.4 ヘルスチェック失敗
+
+**確認項目**：
+1. セキュリティグループでポート8000が開いているか
+2. Djangoアプリケーションが正しく起動しているか
+3. ALLOWED_HOSTSにALBのDNS名が含まれているか
+
+## 7. ベストプラクティス
+
+### 7.1 リソース命名規則
+
+```
+クラスター: django-ecs-cluster-{environment}
+サービス: django-ecs-service-{environment}
+タスク定義: django-app-{environment}
+```
+
+### 7.2 セキュリティ
+
+- IAMロールは最小権限の原則に従う
+- Secrets ManagerまたはSSM Parameter Storeで機密情報を管理
+- プライベートサブネットでタスクを実行
+
+### 7.3 監視
+
+- CloudWatch Logsでアプリケーションログを確認
+- CloudWatch Metricsでリソース使用率を監視
+- X-Rayでアプリケーションのトレースを実施
+
+## 8. よくある質問（FAQ）
+
+**Q: なぜCloudFormationを完全に使わないのか？**
+A: CloudFormationでタスク定義やサービスを管理すると、更新のたびにスタック全体の更新が必要になり、デプロイが遅くなります。基盤インフラのみCloudFormationで管理し、アプリケーションデプロイは高速化のために分離しています。
+
+**Q: VPCを削除したい場合は？**
+A: まず、VPC内のすべてのリソース（ECSサービス、ALB、NAT Gatewayなど）を削除する必要があります。その後、CloudFormationスタックを削除します。
+
+**Q: 本番環境も同じ方式で良いか？**
+A: はい。環境名を変えるだけで同じ方式が使用できます。ただし、本番環境ではBlue/Greenデプロイメントの検討も推奨します。
+
+## 9. 次のステップ
+
+1. **HTTPS対応**：ACM証明書の追加とALBリスナーの設定
+2. **オートスケーリング**：Application Auto Scalingの設定
+3. **Blue/Greenデプロイメント**：CodeDeployとの連携
+4. **監視強化**：DatadogやNew Relicの導入
+
+---
+
+**最終更新日**: 2024年6月19日
+**作成者**: Claude（AI Assistant）
+**レビュー**: 未実施


### PR DESCRIPTION
## 概要
VPC競合問題を回避するため、Option B（ハイブリッド方式）のデプロイ戦略を実装しました。

## 変更内容
- 📝 `docs/staging-deploy.md`: 詳細なデプロイ手順書を作成
- 🔧 `.cursorrules`: ステージングデプロイの必須ガイドラインを追加
- 📋 `task-definition-staging.json`: ECSタスク定義テンプレートを作成
- 🚀 `.github/workflows/auto_deploy_staging.yml`: 固定リソース名を使用するように更新

## Option Bのメリット
1. **VPC上限問題の回避**: 新規VPCを作成せず、既存リソースを再利用
2. **ALB競合の防止**: タイムスタンプ付きスタック名を廃止
3. **高速デプロイ**: インフラ作成なし、アプリケーションのみ更新
4. **シンプルな管理**: 固定リソース名による明確な構成

## テスト方法
1. このPRをdevelopにマージ
2. GitHub Actionsが自動的にステージング環境へデプロイ
3. ステージング環境での動作確認

## チェックリスト
- [x] コードの変更内容を確認
- [x] ドキュメントの更新
- [x] CI/CD設定の確認
- [ ] developブランチへのマージ後の動作確認