### PR TITLE
hotfix: CloudFormation create/update-stack のパラメータ構文を修正

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -67,13 +67,13 @@ jobs:
           aws cloudformation update-stack \
             --stack-name $STACK_NAME \
             --template-body file://cloudformation/ecs-service-staging-simple.yml \
-            --parameter-overrides ImageUrl=$IMAGE_URI
+            --parameters ParameterKey=ImageUrl,ParameterValue=$IMAGE_URI
         else
           echo "Creating new stack: $STACK_NAME"
           aws cloudformation create-stack \
             --stack-name $STACK_NAME \
             --template-body file://cloudformation/ecs-service-staging-simple.yml \
-            --parameter-overrides ImageUrl=$IMAGE_URI
+            --parameters ParameterKey=ImageUrl,ParameterValue=$IMAGE_URI
         fi
           
     - name: Get Application URL


### PR DESCRIPTION
## 概要
CloudFormation  と  コマンドのパラメータ構文エラーを修正します。

## エラー内容


## 修正内容
-  と  では  形式を使用
-  コマンドのみ  形式を使用

## テスト
マージ後、自動的にデプロイワークフローが実行されます。